### PR TITLE
Automagically publish to pypi when releasing on GitHub

### DIFF
--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -1,0 +1,34 @@
+# https://docs.astral.sh/uv/guides/integration/github/#publishing-to-pypi
+# https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+
+name: "Publish"
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi_release
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+      - name: Install Python 3.13
+        run: uv python install 3.13
+      - name: Build
+        run: uv build
+      # Check that basic features work and we didn't miss to include crucial files
+      - name: Smoke test (wheel)
+        run: uv run --isolated --no-project --with dist/*.whl tests/smoke_test.py
+      - name: Smoke test (source distribution)
+        run: uv run --isolated --no-project --with dist/*.tar.gz tests/smoke_test.py
+      # Publish to PyPI
+      - name: Publish
+        run: uv publish


### PR DESCRIPTION
New GHA workflow that uses Trusted Publishing to automatically push to pypi when we cut a release here on GitHub.

The repo environment enforces that it only fires for releases that have a tag starting with `v*`. The Action will then request review from @shorowit or @bpark1327 before pushing up to pypi.